### PR TITLE
drop back to HTTP for Inside Gratipay links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 This repo is used in the review process for [Gratipay](https://gratipay.com/) Team applications.
 
 **Thinking of applying?** Read our review process 
-[documentation](https://inside.gratipay.com/howto/review-teams), and browse [existing 
+[documentation](http://inside.gratipay.com/howto/review-teams), and browse [existing 
 Teams](https://gratipay.com/) for examples of both accepted and rejected applications.
 
 **Ready to apply?** [Go for it](https://gratipay.com/new)!
 
-**Want to help review applications?** Read the [docs](https://inside.gratipay.com/howto/review-teams), 
+**Want to help review applications?** Read the [docs](http://inside.gratipay.com/howto/review-teams), 
 and then [dive in](https://github.com/gratipay/applications/issues)!


### PR DESCRIPTION
Closes https://github.com/gratipay/inside.gratipay.com/issues/659.
